### PR TITLE
Speeding up sparse vector set

### DIFF
--- a/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/mtj/SparseVector.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/mtj/SparseVector.java
@@ -123,12 +123,18 @@ public class SparseVector
         // in there already!
         // (This is to prevent us from adding zeros into the SparseVector
         // unnecessarily)
-        double existing = this.getElement( index );
-        if( existing != value )
+        if (value == 0.0)
         {
-            super.setElement( index, value );
+            final double existing = this.getElement(index);
+            if (existing != 0.0)
+            {
+                super.setElement(index, value);
+            }
         }
-        
+        else
+        {
+            super.setElement(index, value);
+        }
     }
     
     @Override


### PR DESCRIPTION
Avoiding doing a lookup on setting a value in a SparseVector each time, since that requires 2 lookups, which makes it slow. Instead, only do the check when the value passed in is 0 to avoid adding a 0 element to the underlying vector.