### PR TITLE
Fixes issue in Vector equality checks where there is a NaN.

### DIFF
--- a/Components/CommonCore/Source/gov/sandia/cognition/math/MathUtil.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/MathUtil.java
@@ -786,4 +786,47 @@ public class MathUtil
         }
     }
 
+    /**
+     * Compares two double values to see if they are equal. It is safe on values
+     * such as NaN in that if you pass two NaN values they will be equal.
+     * 
+     * @param   x 
+     *      A double.
+     * @param   y 
+     *      Another double.
+     * @return 
+     *      True if x is equal to y.
+     */
+    public static boolean equals(
+        final double x,
+        final double y)
+    {
+        // This comparison method is used to detect if NaNs are equal.
+        return Double.compare(x, y) == 0;
+    }
+    
+    /**
+     * Compares two double values to see if they are equal within the given
+     * bounds for effective zero. It is safe on values
+     * such as NaN in that if you pass two NaN values they will be equal.
+     * 
+     * @param   x 
+     *      A double.
+     * @param   y 
+     *      Another double.
+     * @param   effectiveZero 
+     *      The effective value for zero. Should be non-negative.
+     *      If a value of 0 (or less) is given then it requires strict equality.
+     * @return 
+     *      True if x is equal to y within a value of effectiveZero.
+     */
+    public static boolean equals(
+        final double x,
+        final double y,
+        final double effectiveZero)
+    {
+        // This comparison method is used to detect if NaNs are equal.
+        // But fail when there is a NaN in one but not the other.
+        return (Double.compare(x, y) == 0) || (Math.abs(x - y) <= effectiveZero);
+    }
 }

--- a/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/AbstractVector.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/AbstractVector.java
@@ -16,9 +16,11 @@ package gov.sandia.cognition.math.matrix;
 
 import gov.sandia.cognition.annotation.CodeReview;
 import gov.sandia.cognition.annotation.CodeReviews;
+import gov.sandia.cognition.math.MathUtil;
 import gov.sandia.cognition.math.UnivariateScalarFunction;
 import java.text.NumberFormat;
 import java.util.AbstractList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -87,12 +89,22 @@ public abstract class AbstractVector
         {
             return false;
         }
-        else
+        
+        // Loop through all the defined entries of the two vectors.
+        final Iterator<TwoVectorEntry> iterator = new VectorUnionIterator(
+            this, other);
+        while (iterator.hasNext())
         {
-            return super.equals( other, effectiveZero );
+            final TwoVectorEntry entry = iterator.next();
+            if (!MathUtil.equals(entry.getFirstValue(), entry.getSecondValue(), effectiveZero))
+            {
+                return false;
+            }
         }
+        
+        return true;
     }
-
+ 
     @Override
     public int hashCode()
     {
@@ -235,11 +247,16 @@ public abstract class AbstractVector
         // This is a generic implementation to support interoperability. 
         // Sub-classes should make custom ones for performance.
         this.assertSameDimensionality(other);
+        
+        // Go through all the defined entries in both vectors.
         double result = 0.0;
-        for (final VectorEntry entry : this)
+        final Iterator<TwoVectorEntry> iterator = new VectorUnionIterator(
+            this, other);
+        while (iterator.hasNext())
         {
+            final TwoVectorEntry entry = iterator.next();
             final double difference = 
-                entry.getValue() - other.get(entry.getIndex());
+                entry.getFirstValue() - entry.getSecondValue();
             result += difference * difference;
         }
         return result;

--- a/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/AbstractVectorSpace.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/AbstractVectorSpace.java
@@ -229,15 +229,7 @@ public abstract class AbstractVectorSpace<VectorType extends VectorSpace<VectorT
     {
         return Math.abs(this.norm2() - 1.0) <= tolerance;
     }
-
-    @Override
-    public boolean equals(
-        final VectorType other,
-        final double effectiveZero)
-    {
-        return this.euclideanDistance(other) <= effectiveZero;
-    }
-
+    
     @Override
     public void scaleEquals(
         final double scaleFactor)

--- a/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/custom/DenseVector.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/custom/DenseVector.java
@@ -14,6 +14,7 @@
 package gov.sandia.cognition.math.matrix.custom;
 
 import gov.sandia.cognition.collection.ArrayUtil;
+import gov.sandia.cognition.math.MathUtil;
 import gov.sandia.cognition.math.matrix.Matrix;
 import gov.sandia.cognition.math.matrix.Vector;
 import gov.sandia.cognition.math.matrix.VectorEntry;
@@ -128,6 +129,38 @@ public class DenseVector
         return result;
     }
 
+    
+    @Override
+    public boolean equals(
+        final Vector other,
+        final double effectiveZero)
+    {
+        if (!this.checkSameDimensionality(other))
+        {
+            return false;
+        }
+        
+        // Determine if all entries are within effectiveZero of each other.
+        // If we find a single entry larger than effectiveZero, we know that
+        // the vectors aren't equal, so just return false.  However, if we loop
+        // over all entries and still don't find a large difference, then
+        // we consider the vectors "equal".
+        //
+        // Please note: this structure does not exploit ANY type of sparseness
+        // in either vector.
+        final int dimensionality = this.getDimensionality();
+        for (int i = 0; i < dimensionality; i++)
+        {
+            // Use a NaN-safe comparison.
+            if (!MathUtil.equals(this.values[i], other.get(i), effectiveZero))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    
     @Override
     public void scaledPlusEquals(
         final DenseVector other,

--- a/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/mtj/DenseVector.java
+++ b/Components/CommonCore/Source/gov/sandia/cognition/math/matrix/mtj/DenseVector.java
@@ -18,6 +18,7 @@ import gov.sandia.cognition.annotation.CodeReview;
 import gov.sandia.cognition.annotation.CodeReviewResponse;
 import gov.sandia.cognition.annotation.PublicationReference;
 import gov.sandia.cognition.annotation.PublicationType;
+import gov.sandia.cognition.math.MathUtil;
 import gov.sandia.cognition.math.UnivariateScalarFunction;
 import gov.sandia.cognition.math.matrix.Vector;
 import gov.sandia.cognition.math.matrix.VectorEntry;
@@ -214,7 +215,7 @@ public class DenseVector
     @Override
     public boolean equals(
         final Vector other,
-        double effectiveZero)
+        final double effectiveZero)
     {
         if (!this.checkSameDimensionality(other))
         {
@@ -231,17 +232,16 @@ public class DenseVector
         // in either vector.
         final double[] values = this.getArray();
         final int dimensionality = this.getDimensionality();
-        for( int i = 0; i < dimensionality; i++ )
+        for (int i = 0; i < dimensionality; i++)
         {
-            double difference = values[i] - other.getElement( i );
-            if( Math.abs( difference ) > effectiveZero )
+            // Use a NaN-safe comparison.
+            if (!MathUtil.equals(values[i], other.get(i), effectiveZero))
             {
                 return false;
             }
         }
 
         return true;
-
     }
 
     @Override

--- a/Components/CommonCore/Test/gov/sandia/cognition/math/MathUtilTest.java
+++ b/Components/CommonCore/Test/gov/sandia/cognition/math/MathUtilTest.java
@@ -439,5 +439,80 @@ public class MathUtilTest
             }
         }
     }
+        
+    /**
+     * Test of equals method of class MathUtil.
+     */
+    public void testEquals()
+    {
+        assertTrue(MathUtil.equals(0.0, 0.0));
+        assertFalse(MathUtil.equals(0.0, 1.0));
+        assertFalse(MathUtil.equals(0.0, -1.1));
+        assertTrue(MathUtil.equals(Double.NaN, Double.NaN));
+        assertTrue(MathUtil.equals(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        assertTrue(MathUtil.equals(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY));
+        
+        assertFalse(MathUtil.equals(0.0, Double.NaN));
+        assertFalse(MathUtil.equals(0.0, Double.POSITIVE_INFINITY));
+        assertFalse(MathUtil.equals(0.0, Double.NEGATIVE_INFINITY));
+        assertFalse(MathUtil.equals(Double.NaN, 0.0));
+        assertFalse(MathUtil.equals(Double.POSITIVE_INFINITY, 0.0));
+        assertFalse(MathUtil.equals(Double.NEGATIVE_INFINITY, 0.0));
+        
+        double v = this.RANDOM.nextGaussian();
+        assertTrue(MathUtil.equals(v, v));
+        assertFalse(MathUtil.equals(v, Double.NaN));
+        assertFalse(MathUtil.equals(v, Double.POSITIVE_INFINITY));
+        assertFalse(MathUtil.equals(v, Double.NEGATIVE_INFINITY));
+        assertFalse(MathUtil.equals(Double.NaN, v));
+        assertFalse(MathUtil.equals(Double.POSITIVE_INFINITY, v));
+        assertFalse(MathUtil.equals(Double.NEGATIVE_INFINITY, v));
+        
+        for (double x : this.getGoodValues())
+        {
+            assertTrue(MathUtil.equals(x, x));
+        }
+    }
     
+    /**
+     * Test of equals(double, double, double) method of class MathUtil.
+     */
+    public void testEqualsWithEffectiveZero()
+    {
+        assertTrue(MathUtil.equals(1.0, 1.1, 0.2));
+        
+        double eps = 1e-5;
+        assertTrue(MathUtil.equals(0.0, 0.0, eps));
+        assertFalse(MathUtil.equals(0.0, 1.0, eps));
+        assertFalse(MathUtil.equals(0.0, -1.1, eps));
+        assertTrue(MathUtil.equals(Double.NaN, Double.NaN, eps));
+        assertTrue(MathUtil.equals(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, eps));
+        assertTrue(MathUtil.equals(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, eps));
+        
+        assertFalse(MathUtil.equals(0.0, Double.NaN, eps));
+        assertFalse(MathUtil.equals(0.0, Double.POSITIVE_INFINITY, eps));
+        assertFalse(MathUtil.equals(0.0, Double.NEGATIVE_INFINITY, eps));
+        assertFalse(MathUtil.equals(Double.NaN, 0.0, eps));
+        assertFalse(MathUtil.equals(Double.POSITIVE_INFINITY, 0.0, eps));
+        assertFalse(MathUtil.equals(Double.NEGATIVE_INFINITY, 0.0, eps));
+        
+        double v = this.RANDOM.nextGaussian();
+        assertTrue(MathUtil.equals(v, v, eps));
+        assertFalse(MathUtil.equals(v, Double.NaN, eps));
+        assertFalse(MathUtil.equals(v, Double.POSITIVE_INFINITY, eps));
+        assertFalse(MathUtil.equals(v, Double.NEGATIVE_INFINITY, eps));
+        assertFalse(MathUtil.equals(Double.NaN, v, eps));
+        assertFalse(MathUtil.equals(Double.POSITIVE_INFINITY, v, eps));
+        assertFalse(MathUtil.equals(Double.NEGATIVE_INFINITY, v, eps));
+        
+        assertTrue(MathUtil.equals(v, v + eps / 2.0, eps));
+        assertTrue(MathUtil.equals(v, v + eps / 2.0, eps));
+        assertFalse(MathUtil.equals(v, v + eps * 2.0, eps));
+        assertFalse(MathUtil.equals(v, v + eps * 2.0, eps));
+        
+        for (double x : this.getGoodValues())
+        {
+            assertTrue(MathUtil.equals(x, x, eps));
+        }
+    }
 }

--- a/Components/CommonCore/Test/gov/sandia/cognition/math/matrix/VectorTestHarness.java
+++ b/Components/CommonCore/Test/gov/sandia/cognition/math/matrix/VectorTestHarness.java
@@ -551,6 +551,35 @@ abstract public class VectorTestHarness
     }
     
     /**
+     * Test of equals method with NaNs, of class Vector.
+     */
+    public void testEqualsWithNaN()
+    {
+        System.out.println("equals with NaN");
+
+        Vector v1 = this.createRandom();
+        int M = v1.getDimensionality();
+        assertEquals(v1, v1);
+
+        int index = RANDOM.nextInt( M );
+        
+        Vector v2 = v1.clone();
+        v2.setElement(index, Double.NaN);
+        assertFalse(v1.equals(v2));
+        assertFalse(v2.equals(v1));
+        assertEquals(v2, v2);
+        assertEquals(v2, v2.clone());
+        
+        Vector v3 = this.createVector(M);
+        v3.setElement(index, Double.NaN);
+        assertFalse(v1.equals(v3));
+        assertFalse(v2.equals(v3));
+        assertFalse(v3.equals(v1));
+        assertFalse(v3.equals(v2));
+        assertEquals(v3, v3);
+    }
+    
+    /**
      * Test of hashCode method, of class gov.sandia.isrc.math.matrix.Vector.
      */
     public void testHashCode()


### PR DESCRIPTION
Also fixes an issue in rare case of using AbstractVector 
euclideanDistance that returns an incorrect result in sparse cases. This 
is a rare case, which only gets called when mixing vector implementation 
across packages. The implementation of the equality fix also adds a
utility method for NaN-safe equality checks to MathUtil.